### PR TITLE
fix(map): Allow null as value for Map entry

### DIFF
--- a/src/parsers/map.ts
+++ b/src/parsers/map.ts
@@ -10,11 +10,9 @@ export const fromMap = <T>(map: ParserInput, key: string, valueParser: ParseFn<T
     throw new ParserError('Map', map);
   }
 
-  const value = map[key];
-
-  if (isNil(value)) {
+if (!(key in map)) {
     throw new ParserError(`Map containing key ${key}`, JSON.stringify(map));
   }
 
-  return valueParser(value);
+  return valueParser(map[key]);
 };

--- a/test/parsers/map.ts
+++ b/test/parsers/map.ts
@@ -1,5 +1,5 @@
 import {expect} from 'chai';
-import {ParserError} from '../../src/parsers';
+import {ParserError, ParseFn} from '../../src/parsers';
 import {fromMap} from '../../src/parsers/map';
 import {aBoolean} from '../../src/parsers/boolean';
 
@@ -32,5 +32,10 @@ describe('Parser', () => {
     it('should throw a ParserError when given a string', () => {
       expect(() => fromMap('test', 'a', aBoolean)).to.throw(ParserError);
     });
+
+    it('should not throw ParserError when given key exists and has value "null"', () => {
+      const aNull: ParseFn<null> = (): null => null;
+      expect(() => fromMap({ a: null }, 'a', aNull)).to.not.throw();
+    })
   });
 });


### PR DESCRIPTION
The withMap parser failed when a map contained a key with value "null". This change fixes this an
allows entries with null values.